### PR TITLE
Add stripOutputSchema config for Claude Code compatibility

### DIFF
--- a/internal/config/games.go
+++ b/internal/config/games.go
@@ -49,8 +49,9 @@ type GamesConfig struct {
 	Version            string                   `json:"version"`
 	Games              map[string]GameConfig    `json:"games"`
 	ToolNormalization  *ToolNormalizationConfig `json:"toolNormalization,omitempty"`
-	APIKey             string                   `json:"apiKey,omitempty"` // API key for HTTP server authentication
-	PortRanges         *PortRangeConfig         `json:"portRanges,omitempty"` // Custom port ranges for bridge connections
+	APIKey             string                   `json:"apiKey,omitempty"`             // API key for HTTP server authentication
+	PortRanges         *PortRangeConfig         `json:"portRanges,omitempty"`         // Custom port ranges for bridge connections
+	StripOutputSchema  bool                     `json:"stripOutputSchema,omitempty"`  // Strip outputSchema from tools/list for MCP clients that reject non-standard fields (e.g. Claude Code)
 }
 
 // LoadGamesConfig loads the games configuration from the standard location

--- a/internal/config/games.go
+++ b/internal/config/games.go
@@ -49,9 +49,9 @@ type GamesConfig struct {
 	Version            string                   `json:"version"`
 	Games              map[string]GameConfig    `json:"games"`
 	ToolNormalization  *ToolNormalizationConfig `json:"toolNormalization,omitempty"`
-	APIKey             string                   `json:"apiKey,omitempty"`             // API key for HTTP server authentication
-	PortRanges         *PortRangeConfig         `json:"portRanges,omitempty"`         // Custom port ranges for bridge connections
-	StripOutputSchema  bool                     `json:"stripOutputSchema,omitempty"`  // Strip outputSchema from tools/list for MCP clients that reject non-standard fields (e.g. Claude Code)
+	APIKey             string                   `json:"apiKey,omitempty"` // API key for HTTP server authentication
+	PortRanges         *PortRangeConfig         `json:"portRanges,omitempty"` // Custom port ranges for bridge connections
+	StripOutputSchema  bool                     `json:"stripOutputSchema,omitempty"` // Strip outputSchema from tools/list for MCP clients that reject non-standard fields (e.g. Claude Code)
 }
 
 // LoadGamesConfig loads the games configuration from the standard location

--- a/internal/mcp/stdio_server.go
+++ b/internal/mcp/stdio_server.go
@@ -37,8 +37,9 @@ type Server struct {
 	gabpClients     map[string]*gabp.Client // Track GABP connections per game
 	gabpAttention   map[string]*gameAttentionState
 	gabpDisconnects map[string]gabpDisconnectRecord
-	starter         *process.SerializedStarter // Serialized process starter
-	instanceID      string
+	starter           *process.SerializedStarter // Serialized process starter
+	instanceID        string
+	stripOutputSchema bool // Strip outputSchema from tools/list responses
 }
 
 type gabpDisconnectRecord struct {
@@ -273,6 +274,7 @@ func (s *Server) SetAPIKey(apiKey string) {
 
 // RegisterGameManagementTools registers the game management tools for the new architecture
 func (s *Server) RegisterGameManagementTools(gamesConfig *config.GamesConfig, backoffMin, backoffMax time.Duration) {
+	s.stripOutputSchema = gamesConfig.StripOutputSchema
 	normalizationConfig := gamesConfig.GetToolNormalization()
 
 	// games.list tool
@@ -3142,7 +3144,11 @@ func (s *Server) handleToolsList(msg *Message) *Message {
 
 	tools := make([]Tool, 0, len(s.tools))
 	for _, handler := range s.tools {
-		tools = append(tools, handler.Tool)
+		tool := handler.Tool
+		if s.stripOutputSchema {
+			tool.OutputSchema = nil
+		}
+		tools = append(tools, tool)
 	}
 
 	result := ToolsListResult{Tools: tools}

--- a/internal/mcp/stdio_server.go
+++ b/internal/mcp/stdio_server.go
@@ -37,8 +37,8 @@ type Server struct {
 	gabpClients     map[string]*gabp.Client // Track GABP connections per game
 	gabpAttention   map[string]*gameAttentionState
 	gabpDisconnects map[string]gabpDisconnectRecord
-	starter           *process.SerializedStarter // Serialized process starter
-	instanceID        string
+	starter         *process.SerializedStarter // Serialized process starter
+	instanceID      string
 	stripOutputSchema bool // Strip outputSchema from tools/list responses
 }
 

--- a/internal/mcp/strip_output_schema_test.go
+++ b/internal/mcp/strip_output_schema_test.go
@@ -1,0 +1,144 @@
+package mcp
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/pardeike/gabs/internal/config"
+	"github.com/pardeike/gabs/internal/util"
+)
+
+func TestStripOutputSchema(t *testing.T) {
+	logger := util.NewLogger("warn")
+
+	// Helper to create a server, register tools, add a game tool with outputSchema,
+	// and return the tools/list response.
+	setup := func(strip bool) *Message {
+		server := NewServerForTesting(logger)
+
+		gamesConfig := &config.GamesConfig{
+			StripOutputSchema: strip,
+		}
+		if err := gamesConfig.AddGame(config.GameConfig{
+			ID:         "testgame",
+			Name:       "Test Game",
+			LaunchMode: "DirectPath",
+			Target:     "/bin/true",
+		}); err != nil {
+			t.Fatalf("AddGame: %v", err)
+		}
+
+		server.RegisterGameManagementTools(gamesConfig, 100*time.Millisecond, 5*time.Second)
+
+		// Register a game tool that carries outputSchema (like RimBridgeServer does)
+		server.RegisterGameTool("testgame", Tool{
+			Name:        "testgame.take_screenshot",
+			Description: "Take a screenshot",
+			InputSchema: map[string]interface{}{
+				"type":                 "object",
+				"additionalProperties": false,
+				"properties": map[string]interface{}{
+					"fileName": map[string]interface{}{
+						"type":        "string",
+						"description": "Output file name",
+					},
+				},
+			},
+			OutputSchema: map[string]interface{}{
+				"description": "The screenshot result with file path and dimensions",
+			},
+		}, func(args map[string]interface{}) (*ToolResult, error) {
+			return &ToolResult{Content: []Content{{Type: "text", Text: "ok"}}}, nil
+		}, &config.ToolNormalizationConfig{})
+
+		// Also register one without outputSchema
+		server.RegisterGameTool("testgame", Tool{
+			Name:        "testgame.ping",
+			Description: "Connectivity check",
+			InputSchema: map[string]interface{}{
+				"type":       "object",
+				"properties": map[string]interface{}{},
+			},
+		}, func(args map[string]interface{}) (*ToolResult, error) {
+			return &ToolResult{Content: []Content{{Type: "text", Text: "pong"}}}, nil
+		}, &config.ToolNormalizationConfig{})
+
+		listMsg := &Message{
+			JSONRPC: "2.0",
+			Method:  "tools/list",
+			ID:      json.RawMessage(`"test-list"`),
+		}
+		return server.HandleMessage(listMsg)
+	}
+
+	findTool := func(response *Message, name string) map[string]interface{} {
+		respBytes, _ := json.Marshal(response.Result)
+		var result struct {
+			Tools []map[string]interface{} `json:"tools"`
+		}
+		json.Unmarshal(respBytes, &result)
+		for _, tool := range result.Tools {
+			if tool["name"] == name {
+				return tool
+			}
+		}
+		return nil
+	}
+
+	t.Run("StripOutputSchema_false_preserves_field", func(t *testing.T) {
+		response := setup(false)
+		tool := findTool(response, "testgame.take_screenshot")
+		if tool == nil {
+			t.Fatal("tool testgame.take_screenshot not found in tools/list")
+		}
+		if _, ok := tool["outputSchema"]; !ok {
+			t.Error("expected outputSchema to be present when stripOutputSchema is false")
+		}
+	})
+
+	t.Run("StripOutputSchema_true_removes_field", func(t *testing.T) {
+		response := setup(true)
+		tool := findTool(response, "testgame.take_screenshot")
+		if tool == nil {
+			t.Fatal("tool testgame.take_screenshot not found in tools/list")
+		}
+		if _, ok := tool["outputSchema"]; ok {
+			t.Error("expected outputSchema to be stripped when stripOutputSchema is true")
+		}
+	})
+
+	t.Run("StripOutputSchema_true_preserves_tools_without_it", func(t *testing.T) {
+		response := setup(true)
+		tool := findTool(response, "testgame.ping")
+		if tool == nil {
+			t.Fatal("tool testgame.ping not found in tools/list")
+		}
+		// Should still have name, description, inputSchema
+		if tool["name"] != "testgame.ping" {
+			t.Errorf("expected name testgame.ping, got %v", tool["name"])
+		}
+		if tool["description"] != "Connectivity check" {
+			t.Errorf("expected description 'Connectivity check', got %v", tool["description"])
+		}
+	})
+
+	t.Run("StripOutputSchema_true_preserves_inputSchema", func(t *testing.T) {
+		response := setup(true)
+		tool := findTool(response, "testgame.take_screenshot")
+		if tool == nil {
+			t.Fatal("tool testgame.take_screenshot not found in tools/list")
+		}
+		schema, ok := tool["inputSchema"].(map[string]interface{})
+		if !ok {
+			t.Fatal("inputSchema missing or wrong type")
+		}
+		props, ok := schema["properties"].(map[string]interface{})
+		if !ok {
+			t.Fatal("inputSchema.properties missing")
+		}
+		if _, ok := props["fileName"]; !ok {
+			t.Error("inputSchema.properties.fileName should be preserved")
+		}
+	})
+}

--- a/internal/mcp/strip_output_schema_test.go
+++ b/internal/mcp/strip_output_schema_test.go
@@ -12,9 +12,8 @@ import (
 func TestStripOutputSchema(t *testing.T) {
 	logger := util.NewLogger("warn")
 
-	// Helper to create a server, register tools, add a game tool with outputSchema,
-	// and return the tools/list response.
-	setup := func(strip bool) *Message {
+	// Helper to create a server with game tools (one with outputSchema, one without).
+	setupServer := func(strip bool) *Server {
 		server := NewServerForTesting(logger)
 
 		gamesConfig := &config.GamesConfig{
@@ -64,6 +63,12 @@ func TestStripOutputSchema(t *testing.T) {
 			return &ToolResult{Content: []Content{{Type: "text", Text: "pong"}}}, nil
 		}, &config.ToolNormalizationConfig{})
 
+		return server
+	}
+
+	// Convenience: create server and return tools/list response.
+	setup := func(strip bool) *Message {
+		server := setupServer(strip)
 		listMsg := &Message{
 			JSONRPC: "2.0",
 			Method:  "tools/list",
@@ -72,12 +77,18 @@ func TestStripOutputSchema(t *testing.T) {
 		return server.HandleMessage(listMsg)
 	}
 
-	findTool := func(response *Message, name string) map[string]interface{} {
-		respBytes, _ := json.Marshal(response.Result)
+	findTool := func(t *testing.T, response *Message, name string) map[string]interface{} {
+		t.Helper()
+		respBytes, err := json.Marshal(response.Result)
+		if err != nil {
+			t.Fatalf("failed to marshal response: %v", err)
+		}
 		var result struct {
 			Tools []map[string]interface{} `json:"tools"`
 		}
-		json.Unmarshal(respBytes, &result)
+		if err := json.Unmarshal(respBytes, &result); err != nil {
+			t.Fatalf("failed to unmarshal tools list: %v", err)
+		}
 		for _, tool := range result.Tools {
 			if tool["name"] == name {
 				return tool
@@ -88,7 +99,7 @@ func TestStripOutputSchema(t *testing.T) {
 
 	t.Run("StripOutputSchema_false_preserves_field", func(t *testing.T) {
 		response := setup(false)
-		tool := findTool(response, "testgame.take_screenshot")
+		tool := findTool(t, response, "testgame.take_screenshot")
 		if tool == nil {
 			t.Fatal("tool testgame.take_screenshot not found in tools/list")
 		}
@@ -99,7 +110,7 @@ func TestStripOutputSchema(t *testing.T) {
 
 	t.Run("StripOutputSchema_true_removes_field", func(t *testing.T) {
 		response := setup(true)
-		tool := findTool(response, "testgame.take_screenshot")
+		tool := findTool(t, response, "testgame.take_screenshot")
 		if tool == nil {
 			t.Fatal("tool testgame.take_screenshot not found in tools/list")
 		}
@@ -110,7 +121,7 @@ func TestStripOutputSchema(t *testing.T) {
 
 	t.Run("StripOutputSchema_true_preserves_tools_without_it", func(t *testing.T) {
 		response := setup(true)
-		tool := findTool(response, "testgame.ping")
+		tool := findTool(t, response, "testgame.ping")
 		if tool == nil {
 			t.Fatal("tool testgame.ping not found in tools/list")
 		}
@@ -125,7 +136,7 @@ func TestStripOutputSchema(t *testing.T) {
 
 	t.Run("StripOutputSchema_true_preserves_inputSchema", func(t *testing.T) {
 		response := setup(true)
-		tool := findTool(response, "testgame.take_screenshot")
+		tool := findTool(t, response, "testgame.take_screenshot")
 		if tool == nil {
 			t.Fatal("tool testgame.take_screenshot not found in tools/list")
 		}
@@ -139,6 +150,43 @@ func TestStripOutputSchema(t *testing.T) {
 		}
 		if _, ok := props["fileName"]; !ok {
 			t.Error("inputSchema.properties.fileName should be preserved")
+		}
+	})
+
+	t.Run("StripOutputSchema_true_does_not_mutate_original", func(t *testing.T) {
+		// Use a single server: call handleToolsList with strip=true, then
+		// disable stripping and call again. The second response must still
+		// have outputSchema, proving the original tool was not mutated.
+		server := setupServer(true)
+
+		listMsg := &Message{
+			JSONRPC: "2.0",
+			Method:  "tools/list",
+			ID:      json.RawMessage(`"strip-call"`),
+		}
+		resp1 := server.HandleMessage(listMsg)
+		tool1 := findTool(t, resp1, "testgame.take_screenshot")
+		if tool1 == nil {
+			t.Fatal("tool not found in first call")
+		}
+		if _, ok := tool1["outputSchema"]; ok {
+			t.Fatal("outputSchema should be stripped in first call")
+		}
+
+		// Disable stripping and call again on the same server
+		server.stripOutputSchema = false
+		listMsg2 := &Message{
+			JSONRPC: "2.0",
+			Method:  "tools/list",
+			ID:      json.RawMessage(`"no-strip-call"`),
+		}
+		resp2 := server.HandleMessage(listMsg2)
+		tool2 := findTool(t, resp2, "testgame.take_screenshot")
+		if tool2 == nil {
+			t.Fatal("tool not found in second call")
+		}
+		if _, ok := tool2["outputSchema"]; !ok {
+			t.Error("original tool's outputSchema was mutated by the strip call")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- Add `stripOutputSchema` boolean to `~/.gabs/config.json` that strips `outputSchema` from `tools/list` responses
- Default is `false` — no behavior change for Codex or other MCP clients
- When `true`, enables Claude Code to load all 110+ game tools as direct MCP tools

## Problem
Claude Code rejects MCP servers that include `outputSchema` in tool definitions returned by `tools/list`. This field is not part of the [MCP tools spec](https://modelcontextprotocol.io/specification/2024-11-05/server/tools) (which only defines `name`, `description`, `inputSchema`), nor the [Claude API tool spec](https://platform.claude.com/docs/en/agents-and-tools/tool-use/define-tools).

Only 4 of 110 RimBridgeServer tools carry `outputSchema`, but their presence causes Claude Code to drop the entire GABS server. Confirmed by binary search: stripping `outputSchema` is the only change needed — full tool names, descriptions, and input schemas all work at 123 tools.

## Config usage
```json
{
  "stripOutputSchema": true
}
```

Full tool metadata including `outputSchema` remains accessible via `games.tool_detail`.

## Test plan
- [x] With `stripOutputSchema: false` (default): no behavior change, Codex works as before
- [x] With `stripOutputSchema: true`: all 123 tools (13 core + 110 game) load as direct MCP tools in Claude Code
- [x] Dynamic tool expansion via `tools/list_changed` works — no disconnects after `games.connect`
- [x] Direct tool calls work: `mcp__gabs__rimworld_rimbridge_ping` returns pong

🤖 Generated with [Claude Code](https://claude.com/claude-code)